### PR TITLE
Update import.js

### DIFF
--- a/commands/import.js
+++ b/commands/import.js
@@ -7,10 +7,11 @@ module.exports = {
 	desc: cfg => "Importing data acts as a merge, meaning if there are any " + cfg.lang + "s already registered with the same name as one being imported, the values will be updated instead of registering a new one.",
 	execute: async (bot, msg, args, cfg) => {
 		let file = msg.attachments[0];
-		if(!file) return "Please attach a .json file to import when running this command.\nYou can get a file by running the export command from me or Pluralkit.";
+		if(!file) file = args[0];
+		if(!file) return "Please attach or link to a .json file to import when running this command.\nYou can get a file by running the export command from me or Pluralkit.";
 		let data;
 		try {
-			data = JSON.parse((await request(msg.attachments[0].url)).body);
+			data = JSON.parse((await request(msg.attachments[0] ? msg.attachments[0].url : args[0])).body);
 		} catch(e) {
 			return "Please attach a valid .json file.";
 		}

--- a/commands/import.js
+++ b/commands/import.js
@@ -2,7 +2,7 @@ const request = require("got");
 
 module.exports = {
 	help: cfg => "Import your data from a file",
-	usage: cfg =>  ["import - Attach a compatible .json file when using this command. Data files can be obtained from compatible bots like me and Pluralkit."],
+	usage: cfg =>  ["import [link] - Attach a compatible .json file or supply a link to a file when using this command. Data files can be obtained from compatible bots like me and Pluralkit."],
 	permitted: () => true,
 	desc: cfg => "Importing data acts as a merge, meaning if there are any " + cfg.lang + "s already registered with the same name as one being imported, the values will be updated instead of registering a new one.",
 	execute: async (bot, msg, args, cfg) => {


### PR DESCRIPTION
Lets users link to a .json file in order to import, instead of having to attach it. Saves iOS users who are struggling with it

(the feeling when I forgot to actually make the request)