### PR TITLE
Fix registering issue

### DIFF
--- a/commands/export.js
+++ b/commands/export.js
@@ -2,10 +2,20 @@ module.exports = {
 	help: cfg => "Export your data to a file",
 	usage: cfg =>  ["export - Get a .json file of your data that you can import to compatible bots"],
 	permitted: () => true,
+	groupArgs: true,
 	execute: async (bot, msg, args, cfg) => {
-		let tups = (await bot.db.query("SELECT name, avatar_url, brackets, posts, show_brackets, birthday, description, tag, group_id, group_pos FROM Members WHERE user_id = $1 ORDER BY position", [msg.author.id])).rows;
-		let groups = (await bot.db.query("SELECT id, name, description, tag FROM Groups WHERE user_id = $1 ORDER BY position",[msg.author.id])).rows;
-		let data = { tuppers: tups, groups };
+		let data;
+		if(!args[0]) {
+			let tups = (await bot.db.query("SELECT name, avatar_url, brackets, posts, show_brackets, birthday, description, tag, group_id, group_pos FROM Members WHERE user_id = $1 ORDER BY position", [msg.author.id])).rows;
+			let groups = (await bot.db.query("SELECT id, name, description, tag FROM Groups WHERE user_id = $1 ORDER BY position",[msg.author.id])).rows;
+			data = { tuppers: tups, groups };
+		} else {
+			let tup = (await bot.db.query("SELECT name, avatar_url, brackets, posts, show_brackets, birthday, description, tag, group_id, group_pos FROM Members WHERE user_id = $1 AND LOWER(name) = LOWER($2)", [msg.author.id, args.join(" ")])).rows;
+			if(!tup) return "You don't have a registered " + cfg.lang + " with that name.";
+
+			data = { tuppers: tup, groups: []};
+		}
+
 		try {
 			let channel = await msg.author.getDMChannel(); //get the user's DM channel
 			return await bot.send(channel,"",{name:"tuppers.json",file:Buffer.from(JSON.stringify(data))}); //send it to them in DMs

--- a/commands/register.js
+++ b/commands/register.js
@@ -10,7 +10,8 @@ module.exports = {
 		if(!args[0]) return bot.cmds.help.execute(bot, msg, ["register"], cfg);
 
 		//check arguments
-		let brackets = msg.content.slice(msg.content.indexOf(args[0])+args[0].length+1).trim().split("text");
+		let content = args.join(" ");
+		let brackets = content.slice(content.indexOf(args[0])+args[0].length+1).trim().split("text");
 		let name = args[0].trim();
 		let member = (await bot.db.query("SELECT name,brackets FROM Members WHERE user_id = $1::VARCHAR(32) AND (LOWER(name) = LOWER($2::VARCHAR(32)) OR brackets = $3)",[msg.author.id,name,brackets || []])).rows[0];
 		if(!args[1]) return "Missing argument 'brackets'. Try `" + cfg.prefix + "help register` for usage details.";

--- a/commands/register.js
+++ b/commands/register.js
@@ -10,8 +10,8 @@ module.exports = {
 		if(!args[0]) return bot.cmds.help.execute(bot, msg, ["register"], cfg);
 
 		//check arguments
-		let content = args.join(" ");
-		let brackets = content.slice(content.indexOf(args[0])+args[0].length+1).trim().split("text");
+		// let content = msg.content.replace("tul!register ","");
+		let brackets = msg.content.slice(msg.content.indexOf(args[0], msg.content.indexOf("register")+8)+args[0].length+1).trim().split("text");
 		let name = args[0].trim();
 		let member = (await bot.db.query("SELECT name,brackets FROM Members WHERE user_id = $1::VARCHAR(32) AND (LOWER(name) = LOWER($2::VARCHAR(32)) OR brackets = $3)",[msg.author.id,name,brackets || []])).rows[0];
 		if(!args[1]) return "Missing argument 'brackets'. Try `" + cfg.prefix + "help register` for usage details.";


### PR DESCRIPTION
Fixes bug where commands like `tul!register regi regi:text` would cut text from part of the command prefix/name (resulting in a member named `regi` with brackets `ter regi regi:text`)