### PR TITLE
Cfg fix

### DIFF
--- a/commands/cfg.js
+++ b/commands/cfg.js
@@ -65,7 +65,7 @@ module.exports = {
 				if(!args[2]) return "Must provide name/mention/id of channel to allow.";
 				channels = args.slice(2).map(arg => bot.resolveChannel(msg,arg)).map(ch => { if(ch) return ch.id; else return ch; });
 				if(!channels.find(ch => ch != undefined)) return `Could not find ${channels.length > 1 ? "those channels" : "that channel"}.`;
-				if(channels.find(ch => ch == undefined)) {
+				if(channels.some(ch => ch == undefined)) {
 					out = "Could not find these channels: ";
 					for(let i = 0; i < channels.length; i++)
 						if(!channels[i]) out += args.slice(2)[i] + " ";
@@ -89,7 +89,7 @@ module.exports = {
 				if(!args[2]) return "Must provide name/mention/id of channel to cmdblacklist.";
 				channels = args.slice(2).map(arg => bot.resolveChannel(msg,arg)).map(ch => { if(ch) return ch.id; else return ch; });
 				if(!channels.find(ch => ch != undefined)) return `Could not find ${channels.length > 1 ? "those channels" : "that channel"}.`;
-				if(channels.find(ch => ch == undefined)) {
+				if(channels.some(ch => ch == undefined)) {
 					out = "Could not find these channels: ";
 					for(let i = 0; i < channels.length; i++)
 						if(!channels[i]) out += args.slice(2)[i];
@@ -102,7 +102,7 @@ module.exports = {
 				if(!args[2]) return "Must provide name/mention/id of channel to allow.";
 				channels = args.slice(2).map(arg => bot.resolveChannel(msg,arg)).map(ch => { if(ch) return ch.id; else return ch; });
 				if(!channels.find(ch => ch != undefined)) return `Could not find ${channels.length > 1 ? "those channels" : "that channel"}.`;
-				if(channels.find(ch => ch == undefined)) {
+				if(channels.some(ch => ch == undefined)) {
 					out = "Could not find these channels: ";
 					for(let i = 0; i < channels.length; i++)
 						if(!channels[i]) out += args.slice(2)[i] + " ";

--- a/commands/cfg.js
+++ b/commands/cfg.js
@@ -49,15 +49,10 @@ module.exports = {
 			}
 			switch(args[1]) {
 			case "add":
-				console.log(args);
-				console.log(args.slice(2));
 				if(!args[2]) return "Must provide name/mention/id of channel to blacklist.";
-				channels = args.slice(2).map(arg => {
-					console.log(arg);
-					return bot.resolveChannel(msg,arg)
-				}).map(ch => { if(ch) return ch.id; else return ch; });
+				channels = args.slice(2).map(arg => bot.resolveChannel(msg,arg)).map(ch => { if(ch) return ch.id; else return ch; });
 				if(!channels.find(ch => ch != undefined)) return `Could not find ${channels.length > 1 ? "those channels" : "that channel"}.`;
-				if(channels.find(ch => ch == undefined)) {
+				if(channels.some(ch => ch == undefined)) {
 					out = "Could not find these channels: ";
 					for(let i = 0; i < channels.length; i++)
 						if(!channels[i]) out += args.slice(2)[i];

--- a/commands/cfg.js
+++ b/commands/cfg.js
@@ -49,8 +49,13 @@ module.exports = {
 			}
 			switch(args[1]) {
 			case "add":
+				console.log(args);
+				console.log(args.slice(2));
 				if(!args[2]) return "Must provide name/mention/id of channel to blacklist.";
-				channels = args.slice(2).map(arg => bot.resolveChannel(msg,arg)).map(ch => { if(ch) return ch.id; else return ch; });
+				channels = args.slice(2).map(arg => {
+					console.log(arg);
+					return bot.resolveChannel(msg,arg)
+				}).map(ch => { if(ch) return ch.id; else return ch; });
 				if(!channels.find(ch => ch != undefined)) return `Could not find ${channels.length > 1 ? "those channels" : "that channel"}.`;
 				if(channels.find(ch => ch == undefined)) {
 					out = "Could not find these channels: ";

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -7,7 +7,7 @@ module.exports = async (msg,bot) => {
 	else cfg = { id: null, prefix: "tul!", lang: "tupper"};
 	if (msg.content.startsWith(cfg.prefix) && (!guild || (!(await bot.db.isBlacklisted(guild.id,msg.channel.id,false)) || msg.member.permission.has("manageGuild")))) {
 		let content = msg.content.substr(cfg.prefix.length).trim();
-		let args = content.split(/\s+/g);
+		let args = content.split(/s+/g);
 		let cmd = bot.cmds[args.shift()];
 		if(cmd && bot.checkPermissions(cmd,msg,args)) {
 			let noPerms = false;

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -7,7 +7,7 @@ module.exports = async (msg,bot) => {
 	else cfg = { id: null, prefix: "tul!", lang: "tupper"};
 	if (msg.content.startsWith(cfg.prefix) && (!guild || (!(await bot.db.isBlacklisted(guild.id,msg.channel.id,false)) || msg.member.permission.has("manageGuild")))) {
 		let content = msg.content.substr(cfg.prefix.length).trim();
-		let args = content.split(" ");
+		let args = content.split(/\s+/g);
 		let cmd = bot.cmds[args.shift()];
 		if(cmd && bot.checkPermissions(cmd,msg,args)) {
 			let noPerms = false;

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -7,7 +7,7 @@ module.exports = async (msg,bot) => {
 	else cfg = { id: null, prefix: "tul!", lang: "tupper"};
 	if (msg.content.startsWith(cfg.prefix) && (!guild || (!(await bot.db.isBlacklisted(guild.id,msg.channel.id,false)) || msg.member.permission.has("manageGuild")))) {
 		let content = msg.content.substr(cfg.prefix.length).trim();
-		let args = content.split(/s+/g);
+		let args = content.split(/\s+/g);
 		let cmd = bot.cmds[args.shift()];
 		if(cmd && bot.checkPermissions(cmd,msg,args)) {
 			let noPerms = false;


### PR DESCRIPTION
- Splits non-grouped args by `\s+` to avoid issues like "blacklisting channels with more that one space between them makes the boy\:tm: angry"
- Change `.find` to `.some` where appropriate