### PR TITLE
Show proper IDs in message info

### DIFF
--- a/commands/showuser.js
+++ b/commands/showuser.js
@@ -5,6 +5,6 @@ module.exports = {
 	execute: (bot, msg, args, cfg) => {
 		if(!bot.recent[msg.channel.id])	return "No " + cfg.lang + "s have spoken in this channel since I last started up, sorry.";
 		
-		return `Last ${cfg.lang} message sent by ${bot.recent[msg.channel.id][0].rawname}, registered to ${bot.recent[msg.channel.id][0].tag} (${bot.recent[msg.channel.id][0].id})`;
+		return `Last ${cfg.lang} message sent by ${bot.recent[msg.channel.id][0].rawname}, registered to ${bot.recent[msg.channel.id][0].tag} (${bot.recent[msg.channel.id][0].user_id})`;
 	}
 };

--- a/events/messageReactionAdd.js
+++ b/events/messageReactionAdd.js
@@ -8,7 +8,7 @@ module.exports = async (message, emoji, userID, bot) => {
 	} else if(emoji.name == "\u2753" && bot.recent[message.channel.id]) {
 		let recent = bot.recent[message.channel.id].find(r => message.id == r.id);
 		if(!recent) return;
-		let response = `That proxy was sent by ${recent.tag} (${recent.id}).`;
+		let response = `That proxy was sent by ${recent.tag} (${recent.user_id}).`;
 		let target;
 		try {
 			target = await bot.getDMChannel(userID);


### PR DESCRIPTION
Fixes an issue from my last PR (accidentally used message ID instead of user ID).