### PR TITLE
A few minor help cleanups

### DIFF
--- a/commands/list.js
+++ b/commands/list.js
@@ -1,6 +1,6 @@
 module.exports = {
 	help: cfg => "Get a detailed list of yours or another user's registered " + cfg.lang + "s",
-	usage: cfg =>  ["list [user] - Sends a list of the user's registered " + cfg.lang + "s, their brackets, post count, and birthday (if set). If user is not specified it defaults to the message author. If 'all' or '*' is given, gives a short form list of all tuppers in the server."],
+	usage: cfg =>  ["list [user] - Sends a list of the user's registered " + cfg.lang + "s, their brackets, post count, and birthday (if set). If user is not specified it defaults to the message author.\nThe bot will provide reaction emoji controls for navigating long lists: Arrows navigate through pages, # jumps to a specific page, ABCD jumps to a specific " + cfg.lang + ", and the stop button deletes the message"],
 	permitted: () => true,
 	execute: async (bot, msg, args, cfg, ng = false) => {
 		////short list of all tuppers in server

--- a/commands/list.js
+++ b/commands/list.js
@@ -1,6 +1,6 @@
 module.exports = {
 	help: cfg => "Get a detailed list of yours or another user's registered " + cfg.lang + "s",
-	usage: cfg =>  ["list [user] - Sends a list of the user's registered " + cfg.lang + "s, their brackets, post count, and birthday (if set). If user is not specified it defaults to the message author.\nThe bot will provide reaction emoji controls for navigating long lists: Arrows navigate through pages, # jumps to a specific page, ABCD jumps to a specific " + cfg.lang + ", and the stop button deletes the message"],
+	usage: cfg =>  ["list [user] - Sends a list of the user's registered " + cfg.lang + "s, their brackets, post count, and birthday (if set). If user is not specified it defaults to the message author.\nThe bot will provide reaction emoji controls for navigating long lists: Arrows navigate through pages, # jumps to a specific page, ABCD jumps to a specific " + cfg.lang + ", and the stop button deletes the message."],
 	permitted: () => true,
 	execute: async (bot, msg, args, cfg, ng = false) => {
 		////short list of all tuppers in server

--- a/commands/listng.js
+++ b/commands/listng.js
@@ -1,6 +1,6 @@
 module.exports = {
 	help: cfg => "Like list, but without showing group info.",
-	usage: cfg =>  ["list [user] - Sends a list of the user's registered " + cfg.lang + "s, their brackets, post count, and birthday (if set). If user is not specified it defaults to the message author. If 'all' or '*' is given, gives a short form list of all tuppers in the server."],
+	usage: cfg =>  ["list [user] - Sends a list of the user's registered " + cfg.lang + "s, their brackets, post count, and birthday (if set). If user is not specified it defaults to the message author. If user is not specified it defaults to the message author.\nThe bot will provide reaction emoji controls for navigating long lists: Arrows navigate through pages, # jumps to a specific page, ABCD jumps to a specific " + cfg.lang + ", and the stop button deletes the message"],
 	permitted: () => true,
 	execute: async (bot, msg, args, cfg) => {
 		return bot.cmds.list.execute(bot,msg,args,cfg,true);

--- a/commands/listng.js
+++ b/commands/listng.js
@@ -1,6 +1,6 @@
 module.exports = {
 	help: cfg => "Like list, but without showing group info.",
-	usage: cfg =>  ["list [user] - Sends a list of the user's registered " + cfg.lang + "s, their brackets, post count, and birthday (if set). If user is not specified it defaults to the message author.\nThe bot will provide reaction emoji controls for navigating long lists: Arrows navigate through pages, # jumps to a specific page, ABCD jumps to a specific " + cfg.lang + ", and the stop button deletes the message"],
+	usage: cfg =>  ["list [user] - Sends a list of the user's registered " + cfg.lang + "s, their brackets, post count, and birthday (if set). If user is not specified it defaults to the message author.\nThe bot will provide reaction emoji controls for navigating long lists: Arrows navigate through pages, # jumps to a specific page, ABCD jumps to a specific " + cfg.lang + ", and the stop button deletes the message."],
 	permitted: () => true,
 	execute: async (bot, msg, args, cfg) => {
 		return bot.cmds.list.execute(bot,msg,args,cfg,true);

--- a/commands/listng.js
+++ b/commands/listng.js
@@ -1,6 +1,6 @@
 module.exports = {
 	help: cfg => "Like list, but without showing group info.",
-	usage: cfg =>  ["list [user] - Sends a list of the user's registered " + cfg.lang + "s, their brackets, post count, and birthday (if set). If user is not specified it defaults to the message author. If user is not specified it defaults to the message author.\nThe bot will provide reaction emoji controls for navigating long lists: Arrows navigate through pages, # jumps to a specific page, ABCD jumps to a specific " + cfg.lang + ", and the stop button deletes the message"],
+	usage: cfg =>  ["list [user] - Sends a list of the user's registered " + cfg.lang + "s, their brackets, post count, and birthday (if set). If user is not specified it defaults to the message author.\nThe bot will provide reaction emoji controls for navigating long lists: Arrows navigate through pages, # jumps to a specific page, ABCD jumps to a specific " + cfg.lang + ", and the stop button deletes the message"],
 	permitted: () => true,
 	execute: async (bot, msg, args, cfg) => {
 		return bot.cmds.list.execute(bot,msg,args,cfg,true);

--- a/commands/register.js
+++ b/commands/register.js
@@ -27,7 +27,7 @@ module.exports = {
 			content: `${proper(cfg.lang)} registered!`,
 			embed: {
 				title: name,
-				description: `**Brackets:**\t${brackets[0]}text${brackets[1]}\n**Avatar URL:**\t${avatar}\n\nSample usage: \`${brackets[0]}hello${brackets[1]}\``,
+				description: `**Brackets:**\t${brackets[0]}text${brackets[1]}\n**Avatar URL:**\t${avatar}\n\nTry typing: \`${brackets[0]}hello${brackets[1]}\``,
 				footer: {
 					text: 'If the brackets look wrong, try re-registering using "quotation marks" around the name!'
 				}

--- a/commands/stats.js
+++ b/commands/stats.js
@@ -2,6 +2,7 @@ const util = require("util");
 
 module.exports = {
 	help: cfg => "Show info about the bot.",
+	usage: cfg =>  ["Displays a list of useful technical information about the bot's running processes. Lists technical details of all clusters, useful for monitoring recent outages and the progress of ongoing restarts. Displays the total memory usage and allocation of the bot, along with how many servers the bot is serving. Displays which shard is currently supporting this server and which cluster that shard is a part of."],
 	permitted: msg => true,
 	execute: (bot, msg, args, cfg) => {
 		process.send({name: "postStats", channelID: msg.channel.id, shard: msg.channel.guild ? msg.channel.guild.shard.id : 0});


### PR DESCRIPTION
Edited list and listng to remove references to the old all/* option, and replaced them with small explanations of the emoji reaction options instead.
Gave stats a usage cfg TL;DRing the information it gives so that when help is run on it users don't receive 'Command not found.'