### PR TITLE
Updates to text in remove

### DIFF
--- a/commands/remove.js
+++ b/commands/remove.js
@@ -2,8 +2,9 @@ const {article,proper} = require("../modules/lang");
 
 module.exports = {
 	help: cfg => "Unregister " + article(cfg) + " " + cfg.lang + "",
-	usage: cfg =>  ["remove <name> - Unregister the named " + cfg.lang + " from your list",
-		"remove * - Unregister ALL of your " + cfg.lang + "s (requires confirmation)"],
+	usage: cfg =>  [
+		"remove <name> [name] [name] ... - Unregisters all named " + cfg.lang + "s from your list.",
+		"remove * - Unregister ALL of your " + cfg.lang + "s (requires confirmation)."],
 	permitted: () => true,
 	groupArgs: true,
 	execute: async (bot, msg, args, cfg, members) => {
@@ -38,7 +39,7 @@ module.exports = {
 					if ((removedMessage.length + notRemovedMessage.length + arg.length) < baseLength) notRemovedMessage += ` '${arg}'`; else notRemovedMessage += " (...)";
 				}
 			}
-			if (removedMessage.length == rOriginalLength.removedMessage) return `No ${cfg.lang}s found.`;
+			if (removedMessage.length == rOriginalLength.removedMessage) return `No ${cfg.lang}s found. If you are trying to remove only a single ${cfg.lang}, make sure to wrap its name in quotes.`;
 			if (notRemovedMessage.length == rOriginalLength.notRemovedMessage) return removedMessage;
 			return `${removedMessage}\n${notRemovedMessage}`;
 		}


### PR DESCRIPTION
Edited the usage to mention the optional multi-remove feature.
Added a reminder to use quotes in the case that a user tries to remove multiple tups and none are found, since that's the most likely cause of that response appearing.

Tried to keep some of the code/text formatting decisions from Aries' PR to but haven't kept up with that enough to know if I should have copied the entire new modular format for mergability or none at all because it's not ready yet, so l compromised on just editing the current format so it could be merged by itself regardless. Bap me if I should go fully either way.